### PR TITLE
Make the homepage copy more launch ready

### DIFF
--- a/source/index.html.haml
+++ b/source/index.html.haml
@@ -12,10 +12,6 @@ description: Build and distribution service for Flatpak applications.
         .col-sm-8.col-sm-offset-2
           %p
             Flathub is a build and distribution service for Flatpak applications. Its goal is to act as a central hub for making desktop applications available to users.
-      .row
-        .col-sm-8.col-sm-offset-2
-          %p
-            This service is in the early stages of development. If you are interested in helping us to build it, please get in touch using the standard Flatpak communication channels.
     
 %section
   .container
@@ -23,7 +19,7 @@ description: Build and distribution service for Flatpak applications.
       .col-sm-8.col-sm-offset-2
         %h2#using Using Flathub
         %p
-          If you would like to help test Flathub, you can add the repository and install apps from it. To do this, you will need to install Flatpak, if you haven't already. After that, there are two options:
+          To get apps from Flathub, you need to add the repository. To do this, you will need to install Flatpak, if you haven't already. After that, there are two options:
         %p
           If you are on Arch, Debian Stretch (or later), Endless OS, Fedora 25 (or later), Mageia 6 (or later), or OpenSUSE Tumbleweed, you can 
           = link_to "download", "https://flathub.org/repo/flathub.flatpakrepo"


### PR DESCRIPTION
As flathub becomes more mature we need to make the copy more confident. Here's an example of some copy changes that might help. Obviously a redesigned page would help more but this felt like the minimal amount of effort that might be useful.

Thoughts (or pushback!) welcome!