### PR TITLE
add missing app to webpage (Cockatrice)

### DIFF
--- a/data/appstream.json
+++ b/data/appstream.json
@@ -1973,6 +1973,18 @@
       "summary": "Personal document manager"
     },
     {
+      "color": "#EDFFE5",
+      "flatpakref": "https://flathub.org/repo/appstream/io.github.Cockatrice.cockatrice.flatpakref",
+      "icons": {
+        "128": "?",
+        "64": "?"
+      },
+      "id": "io.github.Cockatrice.desktop",
+      "name": "Cockatrice",
+      "ref": "?",
+      "summary": "A virtual tabletop for multiplayer card games"
+    },
+    {
       "color": "#C2B6AD",
       "flatpakref": "https://flathub.org/repo/appstream/ws.openarena.OpenArena.flatpakref",
       "icons": {

--- a/data/appstream.json
+++ b/data/appstream.json
@@ -1982,7 +1982,7 @@
       "id": "io.github.Cockatrice.desktop",
       "name": "Cockatrice",
       "ref": "?",
-      "summary": "A virtual tabletop for multiplayer card games"
+      "summary": "A cross-platform virtual tabletop for multiplayer card games"
     },
     {
       "color": "#C2B6AD",


### PR DESCRIPTION
As suggested by @nedrichards in https://github.com/flathub/io.github.Cockatrice.cockatrice/pull/1#issuecomment-350025404, this is a PR to add the missing <kbd>Cockatrice</kbd> app to your list of available packages: https://flathub.org/apps.html

- `flatpakref`: took the name of the [package repo at flathub](https://github.com/flathub/io.github.Cockatrice.cockatrice)
- `icons`:  how can one provide a icon to host on your page?
- `id`: is taken from https://github.com/flathub/io.github.Cockatrice.cockatrice/blob/master/io.github.Cockatrice.appdata.xml#L3
- `ref`: no idea what belongs here

I didn't realize any logical order in the file, so I edited it in at the bottom...

Please double check all data!