### PR TITLE
add two missing items to readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,12 @@ Flathub.org website
 
 To set up middleman locally on Fedora:
 
-install ruby, rubygems and rubygem-bundler
+    dnf install ruby rubygems rubygem-bundler rubygem-json
 
 In the git checkout, do a `bundle install`. This installs all 
 the needed modules in their appropriate vesions.
+
+Add the middleman binary location (probably ~/bin) to $PATH.
 
 To run a local web server to test the site:
 


### PR DESCRIPTION
The setup instructions didnt work for me on Fedora 27 - it required rubygem-json, and ~/bin needed to be added to $PATH.