### PR TITLE
Fix apps link to be absolute

### DIFF
--- a/data/menu.yml
+++ b/data/menu.yml
@@ -1,4 +1,4 @@
 - title: Browse apps
-  link: "apps"
+  link: "/apps"
 - title: Submit an app
   link: "https://github.com/flathub/flathub/wiki/App-Submission"


### PR DESCRIPTION
/apps/ is a folder now, so linking to "apps" makes a non-existent /apps/apps URL