### PR TITLE
fix app submission link

### DIFF
--- a/data/menu.yml
+++ b/data/menu.yml
@@ -1,5 +1,5 @@
 - title: Submit an app
-  link: "https://github.com/flathub/flathub/wiki/Package-Guidelines"
+  link: "https://github.com/flathub/flathub/wiki/App-Submission"
 - title: About
   link: "/about"
 


### PR DESCRIPTION
It looks like that the previous fix was reverted by mistake.